### PR TITLE
fix: resolve Jython site module import error / 241022 / complete

### DIFF
--- a/src/main/java/meowKai/CQuiS_backend/application/QuizServiceImpl.java
+++ b/src/main/java/meowKai/CQuiS_backend/application/QuizServiceImpl.java
@@ -31,6 +31,7 @@ public class QuizServiceImpl implements QuizService {
     // Jython을 위한 세팅
     @PostConstruct
     public void init() {
+        System.setProperty("python.import.site", "false");
         interpreter = new PythonInterpreter(); // Python 인터프리터 생성
 
         // 인코딩 설정


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [x] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
site module import 에러 수정
 
## 💊버그 해결
Jython이 site 모듈을 불러오지 못해서 발생하는 에러로 PythonInterpreter를 초기화할 때 설정을 추가함
 
