### PR TITLE
feat: add transfer host, leader and exit room / 241023 / on going

### DIFF
--- a/src/main/java/meowKai/CQuiS_backend/application/GameRoomService.java
+++ b/src/main/java/meowKai/CQuiS_backend/application/GameRoomService.java
@@ -1,9 +1,6 @@
 package meowKai.CQuiS_backend.application;
 
-import meowKai.CQuiS_backend.dto.request.RequestCreateMultiRoomDto;
-import meowKai.CQuiS_backend.dto.request.RequestKickUserDto;
-import meowKai.CQuiS_backend.dto.request.RequestReadyDto;
-import meowKai.CQuiS_backend.dto.request.RequestSwitchTeamDto;
+import meowKai.CQuiS_backend.dto.request.*;
 import meowKai.CQuiS_backend.dto.response.*;
 
 
@@ -13,4 +10,7 @@ public interface GameRoomService {
     ResponseSwitchTeamDto switchTeam(RequestSwitchTeamDto requestSwitchTeamDto); // 유저의 팀 바꾸기
     ResponseReadyDto ready(RequestReadyDto requestReadyDto); // 준비하기
     ResponseKickUserDto kickUser(RequestKickUserDto requestKickUserDto); // 유저 강퇴(방장 권한 필요)
+    ResponseYieldDto changeHost(RequestYieldDto requestYieldDto); // 방장 권한 위임
+    ResponseYieldDto changeLeader(RequestYieldDto requestYieldDto); // 리더 권한 위임
+    void exit(RequestExitDto requestExitDto); // 현재 들어와 있는 방에서 퇴장
 }

--- a/src/main/java/meowKai/CQuiS_backend/dto/request/RequestExitDto.java
+++ b/src/main/java/meowKai/CQuiS_backend/dto/request/RequestExitDto.java
@@ -1,0 +1,14 @@
+package meowKai.CQuiS_backend.dto.request;
+
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class RequestExitDto {
+
+    private Long roomUserId;
+    private Long roomId;
+}

--- a/src/main/java/meowKai/CQuiS_backend/dto/request/RequestYieldDto.java
+++ b/src/main/java/meowKai/CQuiS_backend/dto/request/RequestYieldDto.java
@@ -1,0 +1,15 @@
+package meowKai.CQuiS_backend.dto.request;
+
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class RequestYieldDto {
+
+    private Long roomUserId;
+    private Long yieldUserId;
+    private Long roomId;
+}

--- a/src/main/java/meowKai/CQuiS_backend/dto/response/ResponseYieldDto.java
+++ b/src/main/java/meowKai/CQuiS_backend/dto/response/ResponseYieldDto.java
@@ -1,0 +1,12 @@
+package meowKai.CQuiS_backend.dto.response;
+
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ResponseYieldDto {
+    private Long yieldedUserId;
+}

--- a/src/main/java/meowKai/CQuiS_backend/presentation/MultiQuizController.java
+++ b/src/main/java/meowKai/CQuiS_backend/presentation/MultiQuizController.java
@@ -6,10 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import meowKai.CQuiS_backend.application.GameRoomService;
 import meowKai.CQuiS_backend.dto.MultiRoomListDto;
-import meowKai.CQuiS_backend.dto.request.RequestCreateMultiRoomDto;
-import meowKai.CQuiS_backend.dto.request.RequestKickUserDto;
-import meowKai.CQuiS_backend.dto.request.RequestReadyDto;
-import meowKai.CQuiS_backend.dto.request.RequestSwitchTeamDto;
+import meowKai.CQuiS_backend.dto.request.*;
 import meowKai.CQuiS_backend.dto.response.*;
 import meowKai.CQuiS_backend.global.base.ApiResponse;
 import org.springframework.web.bind.annotation.*;
@@ -61,5 +58,29 @@ public class MultiQuizController {
     public ApiResponse<Object> kickUser(@Valid @RequestBody RequestKickUserDto requestDto) {
         ResponseKickUserDto responseDto = gameRoomService.kickUser(requestDto);
         return ApiResponse.ofSuccess(responseDto);
+    }
+
+    @Tag(name = "멀티모드 퀴즈")
+    @Operation(summary = "방장 위임")
+    @PostMapping("/yield-host")
+    public ApiResponse<Object> changeHost(@Valid @RequestBody RequestYieldDto requestDto) {
+        ResponseYieldDto responseDto = gameRoomService.changeHost(requestDto);
+        return ApiResponse.ofSuccess(responseDto);
+    }
+
+    @Tag(name = "멀티모드 퀴즈")
+    @Operation(summary = "리더 위임")
+    @PostMapping("/yield-leader")
+    public ApiResponse<Object> changeLeader(@Valid @RequestBody RequestYieldDto requestDto) {
+        ResponseYieldDto responseDto = gameRoomService.changeLeader(requestDto);
+        return ApiResponse.ofSuccess(responseDto);
+    }
+
+    @Tag(name = "멀티모드 퀴즈")
+    @Operation(summary = "방 퇴장")
+    @PostMapping("/exit")
+    public ApiResponse<Object> exitRoom(@Valid @RequestBody RequestExitDto requestDto) {
+        gameRoomService.exit(requestDto); // responseDto로 무엇을 돌려줘야 할까요? RoomUser나 GameRoom의 id를 돌려줬다가 그게 없어졌는데 조회해버리면 어떡하죠?
+        return ApiResponse.ofSuccess();
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

방장, 리더 위임
퇴장 기능 (완벽하지 않음)
 
## 💬리뷰 요구사항

`MultiQuizController.java` 의 `exitRoom` 
`GameRoomServiceImpl` 의 `hostTransfer`, `leaderTransfer` 주석 좀 봐주십쇼!

그리고 다른 유저에게 명예를 주는 기능에 대해...
우리는 명예를 받은 ROOMUSER의 id를 알고있으니 그걸로 USER(ROOMUSER아님)를 찾아서 연관관계 매핑된 USER_STATISTICS를 또 찾아서 명예를 +1 해주는 게 맞을까요?

또 JpaRepository를 사용할 때 메소드 명이 어디까지 복잡해도 되는지 궁금합니다.
예를 들어서 방장을 위임하기 위해 위임받을 유저를 찾는 메소드를 만들고 싶다고 가정해보겠습니다.
RoomUserRepository에서 roomId를 가지는 유저를 찾아서 그 중 현재 가진 userid와는 다른 id를 갖는 user를 찾는 함수를 만들고 싶다면
`Optional<RoomUser> findFirstByGameRoom_IdAndIdNot(Long roomId, Long userId)` 라는 메소드를 만들 수 있지 않겠습니까?
근데 저렇게 써도 되는건지 궁금해서요 계속 길어지면 Querydsl을 써야하는 건가요?

리뷰 달아주시면 다시 빠르게 수정하겠습니다. 감사 <(_ _)>
